### PR TITLE
Add learning customers and live simulation

### DIFF
--- a/live_simulation.py
+++ b/live_simulation.py
@@ -1,0 +1,37 @@
+"""Run an open-ended supermarket simulation with a simple live display."""
+
+import datetime as dt
+import random
+import time
+from store_ai import StoreAI, CustomerAgent
+
+catalogue = {
+    "bread": {"case": 20, "lead": 2, "safety": 15, "cost": 1.2, "price": 2.5},
+    "milk":  {"case": 12, "lead": 1, "safety": 10, "cost": 0.6, "price": 1.5},
+    "eggs":  {"case": 30, "lead": 3, "safety": 25, "cost": 2.0, "price": 3.5},
+}
+
+store = StoreAI(catalogue)
+customers = [CustomerAgent() for _ in range(50)]
+
+today = dt.date(2025, 7, 12)
+
+day = 0
+try:
+    while True:
+        for cust in customers:
+            if random.random() < 0.6:
+                store.serve(today, cust)
+        store.daily_tick(today)
+        snap = store.snapshot()
+        print(
+            f"Day {day:4d} | Profit ${snap['profit']:.2f} | On hand {snap['on_hand']}",
+            end="\r",
+            flush=True,
+        )
+        day += 1
+        today += dt.timedelta(days=1)
+        time.sleep(0.1)
+except KeyboardInterrupt:
+    print("\nSimulation terminated by user.")
+    print(store.snapshot())

--- a/run_simulation.py
+++ b/run_simulation.py
@@ -1,24 +1,25 @@
-"""Run a 30‑day supermarket simulation using the minimalist StoreAI."""
+"""Run a 30‑day supermarket simulation with learning customer agents."""
 
 import datetime as dt
 import random
 import pprint
 
-from store_ai import StoreAI
+from store_ai import StoreAI, CustomerAgent
 
 # --------------------------------------------------------------------- #
 # 1. Static catalogue definition                                        #
 # --------------------------------------------------------------------- #
 catalogue = {
-    "bread": {"case": 20, "lead": 2, "safety": 15},
-    "milk":  {"case": 12, "lead": 1, "safety": 10},
-    "eggs":  {"case": 30, "lead": 3, "safety": 25},
+    "bread": {"case": 20, "lead": 2, "safety": 15, "cost": 1.2, "price": 2.5},
+    "milk":  {"case": 12, "lead": 1, "safety": 10, "cost": 0.6, "price": 1.5},
+    "eggs":  {"case": 30, "lead": 3, "safety": 25, "cost": 2.0, "price": 3.5},
 }
 
 # --------------------------------------------------------------------- #
 # 2. Run simulation                                                     #
 # --------------------------------------------------------------------- #
 store = StoreAI(catalogue, alpha=0.2)
+customers = [CustomerAgent() for _ in range(50)]
 
 start_date = dt.date(2025, 7, 12)
 DAYS = 30
@@ -26,10 +27,10 @@ DAYS = 30
 for day in range(DAYS):
     today = start_date + dt.timedelta(days=day)
 
-    # pseudo‑random customer traffic
-    for _ in range(random.randint(30, 60)):
-        sku = random.choice(list(catalogue))
-        store.sell(today, sku)
+    # each customer may shop once per day with some probability
+    for cust in customers:
+        if random.random() < 0.6:
+            store.serve(today, cust)
 
     store.daily_tick(today)
 
@@ -38,3 +39,13 @@ for day in range(DAYS):
 # --------------------------------------------------------------------- #
 print(f"\nFinal inventory snapshot after {DAYS} days:")
 pprint.pprint(store.snapshot())
+
+print("\nSummary:")
+print(f"  Revenue         : ${store.revenue:.2f}")
+print(f"  Expenses        : ${store.expenses:.2f}")
+print(f"  Profit          : ${store.revenue - store.expenses:.2f}")
+print(f"  Inventory Value : ${store.snapshot()['inventory_value']:.2f}")
+
+print("\nOrders placed:")
+for day, sku, qty, cost in store.orders_log:
+    print(f"  {day}: ordered {qty} of {sku} costing ${cost:.2f}")

--- a/store_ai.py
+++ b/store_ai.py
@@ -1,29 +1,62 @@
 import collections
 import datetime as dt
 import math
+import random
+
+
+class CustomerAgent:
+    """Tiny learning agent representing a supermarket shopper."""
+
+    def __init__(self, preferences: dict[str, float] | None = None):
+        self.preferences = preferences or {}
+
+    def choose_item(self, store: "StoreAI") -> tuple[str, int]:
+        items = list(store.cat)
+        weights = [self.preferences.get(sku, 1.0) for sku in items]
+        sku = random.choices(items, weights=weights, k=1)[0]
+        qty = random.randint(1, 3)
+        return sku, qty
+
+    def learn(self, sku: str, success: bool) -> None:
+        mult = 1.1 if success else 0.9
+        self.preferences[sku] = self.preferences.get(sku, 1.0) * mult
+
 
 class StoreAI:
     """Very small-footprint inventory brain for a single supermarket."""
 
     def __init__(self, catalogue: dict[str, dict], alpha: float = 0.2):
-        """        Args:
-            catalogue: mapping sku -> {case, lead, safety}
+        """Initialize a new ``StoreAI`` instance.
+
+        Args:
+            catalogue: mapping sku -> {case, lead, safety, cost, price}
                       case   : case‑pack size (int, must divide ordered quantity)
                       lead   : supplier lead‑time in days (int >= 0)
                       safety : units of safety stock to buffer uncertainty
+                      cost   : unit cost from supplier (float)
+                      price  : unit selling price (float)
             alpha: smoothing factor for exponential demand average (0 < alpha ≤ 1)
         """
         self.cat = catalogue
         self.alpha = alpha
 
+        # keep separate cost and dynamic price tables
+        self.cost = {sku: info.get("cost", 0.0) for sku, info in catalogue.items()}
+        self.price = {sku: info.get("price", 0.0) for sku, info in catalogue.items()}
+
         # mutable state
         self.on_hand = {k: 10 for k in catalogue}       # start with 10 of each sku
         self.on_order = {k: 0 for k in catalogue}
         self.demand_hat = {k: 1.0 for k in catalogue}   # initial demand estimate (units/day)
+        self.revenue = 0.0
+        self.expenses = 0.0
         self.sales_log: list[tuple[dt.date, str, int]] = []
 
         # future deliveries pipeline: arrival_day -> list[(sku, qty)]
         self._order_pipe = collections.defaultdict(list)
+
+        # track ordering activity
+        self.orders_log: list[tuple[dt.date, str, int, float]] = []
 
     # --------------------------------------------------------------------- #
     #  Public API                                                           #
@@ -40,6 +73,7 @@ class StoreAI:
 
         self.on_hand[sku] -= qty
         self.sales_log.append((ts, sku, qty))
+        self.revenue += self.price.get(sku, 0) * qty
 
         # exponential smoothing update
         self.demand_hat[sku] = (
@@ -47,10 +81,16 @@ class StoreAI:
         )
         return True
 
+    def serve(self, ts: dt.date, customer: CustomerAgent) -> None:
+        sku, qty = customer.choose_item(self)
+        success = self.sell(ts, sku, qty)
+        customer.learn(sku, success)
+
     def daily_tick(self, today: dt.date) -> None:
         """Advance simulation by one day: receive deliveries and place new orders."""
         self._receive_arrivals(today)
         self._reorder(today)
+        self._adjust_prices()
 
     def snapshot(self) -> dict:
         """Current inventory + demand estimate (for debugging / reporting)."""
@@ -58,6 +98,11 @@ class StoreAI:
             "on_hand": self.on_hand.copy(),
             "on_order": self.on_order.copy(),
             "demand_hat": self.demand_hat.copy(),
+            "price": {k: round(v, 2) for k, v in self.price.items()},
+            "inventory_value": round(self._inventory_value(), 2),
+            "revenue": round(self.revenue, 2),
+            "expenses": round(self.expenses, 2),
+            "profit": round(self.revenue - self.expenses, 2),
         }
 
     # --------------------------------------------------------------------- #
@@ -83,5 +128,26 @@ class StoreAI:
             order_qty = math.ceil(gap / case) * case
 
             self.on_order[sku] += order_qty
+            cost = order_qty * self.cost.get(sku, 0)
+            self.expenses += cost
             arrival_day = today + dt.timedelta(days=L)
             self._order_pipe[arrival_day].append((sku, order_qty))
+            self.orders_log.append((today, sku, order_qty, cost))
+
+    def _adjust_prices(self) -> None:
+        """Simple dynamic pricing based on inventory position."""
+        for sku, info in self.cat.items():
+            target_pos = self.demand_hat[sku] * info["lead"] + info["safety"]
+            pos = self.on_hand[sku] + self.on_order[sku]
+            if pos > 1.5 * target_pos:
+                self.price[sku] *= 0.9
+            elif pos < 0.5 * target_pos:
+                self.price[sku] *= 1.1
+
+            # keep price above cost with minimal margin
+            min_price = self.cost.get(sku, 0) * 1.05
+            if self.price[sku] < min_price:
+                self.price[sku] = min_price
+
+    def _inventory_value(self) -> float:
+        return sum(self.on_hand[sku] * self.cost.get(sku, 0) for sku in self.cat)


### PR DESCRIPTION
## Summary
- introduce `CustomerAgent` that learns preferences after shopping
- extend `StoreAI` with `serve` method for interacting with customers
- update `run_simulation.py` to use many learning customer agents
- provide `live_simulation.py` script to run indefinitely with a simple display

## Testing
- `python -m py_compile run_simulation.py store_ai.py live_simulation.py`
- `python run_simulation.py`
- `python live_simulation.py` *(killed after a short run)*

------
https://chatgpt.com/codex/tasks/task_e_68722e0d8d5483308c4f207f13230115